### PR TITLE
Add OpenAI and WhatsApp integrated admin platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env
+npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,83 @@
-# contratamais
+# ContrataMais
+
+Plataforma de atendimento inteligente que integra o OpenAI API com o WhatsApp Cloud API e oferece um painel administrativo para acompanhar conversas, enviar respostas automáticas e registrar o histórico em um banco de dados (arquivo JSON). O projeto foi pensado para ser executado em ambientes simples, como a hospedagem da Hostinger, sem dependências nativas adicionais.
+
+## Recursos principais
+
+- **Integração OpenAI**: geração automática de respostas personalizadas para o contexto da ContrataMais.
+- **Integração WhatsApp Cloud API**: envio de mensagens automáticas ou manuais diretamente pelo painel.
+- **Webhook do WhatsApp**: recepção de mensagens e atualização do histórico em tempo real.
+- **Dashboard administrativo**: interface web responsiva para visualizar conversas, histórico de mensagens e enviar respostas.
+- **Banco de dados baseado em arquivo**: armazenamento local em `data/database.json`, fácil de fazer backup ou migrar para outro SGBD futuramente.
+
+## Pré-requisitos
+
+- Node.js 18 ou superior (para utilizar o `fetch` nativo).
+- Variáveis de ambiente configuradas:
+  - `OPENAI_API_KEY` – chave de API da OpenAI.
+  - `OPENAI_MODEL` *(opcional)* – modelo a ser utilizado (padrão `gpt-4o-mini`).
+  - `OPENAI_BASE_URL` *(opcional)* – URL para proxies como Azure OpenAI.
+  - `WHATSAPP_ACCESS_TOKEN` – token de acesso do WhatsApp Cloud.
+  - `WHATSAPP_PHONE_NUMBER_ID` – identificador do número conectado ao WhatsApp Cloud.
+  - `WHATSAPP_VERIFY_TOKEN` – token de verificação utilizado no webhook.
+  - `PORT` *(opcional)* – porta para executar o servidor (padrão `3000`).
+
+Crie um arquivo `.env` na raiz do projeto se preferir:
+
+```env
+OPENAI_API_KEY=coloque_sua_chave_aqui
+WHATSAPP_ACCESS_TOKEN=token_meta
+WHATSAPP_PHONE_NUMBER_ID=000000000000000
+WHATSAPP_VERIFY_TOKEN=token_de_verificacao
+```
+
+## Instalação
+
+Como todo o projeto utiliza apenas módulos nativos do Node, não há dependências externas obrigatórias. Basta clonar o repositório (ou enviar os arquivos para o servidor) e executar:
+
+```bash
+npm start
+```
+
+O servidor ficará disponível em `http://localhost:3000`.
+
+## Estrutura do projeto
+
+```
+├── data/
+│   └── database.json        # "Banco" de dados em formato JSON
+├── public/
+│   ├── admin.html           # Painel administrativo
+│   ├── app.js               # Lógica do painel (fetch das APIs)
+│   └── styles.css           # Estilos do painel
+├── src/
+│   ├── controllers/
+│   │   └── api.js           # Rotas da API e webhook do WhatsApp
+│   ├── services/
+│   │   ├── openai.js        # Comunicação com a API da OpenAI
+│   │   └── whatsapp.js      # Comunicação com o WhatsApp Cloud API
+│   ├── utils/
+│   │   ├── env.js           # Carregamento simples do arquivo .env
+│   │   ├── http.js          # Helpers de parsing e resposta HTTP
+│   │   ├── logger.js        # Logger simples com timestamp
+│   │   └── static.js        # Servidor de arquivos estáticos
+│   ├── database.js          # Repositório em JSON
+│   └── server.js            # Servidor HTTP principal
+├── package.json
+└── README.md
+```
+
+## Webhook do WhatsApp
+
+Configure a URL `https://seu-dominio/webhooks/whatsapp` na Meta e utilize o mesmo `WHATSAPP_VERIFY_TOKEN`. O endpoint implementa tanto a verificação por GET quanto o processamento das mensagens recebidas via POST.
+
+## Próximos passos sugeridos
+
+- Migrar o armazenamento para um banco gerenciado (PostgreSQL, MySQL, etc.).
+- Adicionar autenticação ao painel administrativo.
+- Agendar tarefas (cron) para envio de campanhas ou lembretes.
+- Implementar filas de processamento para volumes maiores de mensagens.
+
+## Licença
+
+Distribuído sob a licença MIT. Veja `LICENSE` (adicione se necessário).

--- a/data/database.json
+++ b/data/database.json
@@ -1,0 +1,4 @@
+{
+  "messages": [],
+  "conversations": []
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "contratamais",
+  "version": "1.0.0",
+  "description": "Plataforma de atendimento inteligente ContrataMais com integrações OpenAI e WhatsApp Cloud.",
+  "main": "src/server.js",
+  "scripts": {
+    "start": "node src/server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/public/admin.html
+++ b/public/admin.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ContrataMais • Painel de Atendimento</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <div class="brand">
+        <span class="logo">ContrataMais</span>
+        <span class="subtitle">Central Inteligente de WhatsApp</span>
+      </div>
+      <div class="environment">
+        <strong>Ambiente:</strong>
+        <span id="environmentLabel">Desconhecido</span>
+      </div>
+    </header>
+
+    <main class="app-layout">
+      <section class="conversations">
+        <div class="section-header">
+          <h2>Conversas</h2>
+          <button id="refreshConversations" class="secondary">Atualizar</button>
+        </div>
+        <ul id="conversationList" class="conversation-list"></ul>
+      </section>
+
+      <section class="messages">
+        <div class="section-header">
+          <div>
+            <h2 id="conversationTitle">Selecione uma conversa</h2>
+            <p id="conversationSubtitle" class="muted"></p>
+          </div>
+          <button id="refreshMessages" class="secondary" disabled>Recarregar</button>
+        </div>
+        <div id="messageHistory" class="message-history">
+          <div class="empty-state">Escolha um contato para visualizar o histórico.</div>
+        </div>
+
+        <div class="composer">
+          <div class="composer-tabs">
+            <button data-mode="ai" class="composer-tab active">Assistente IA</button>
+            <button data-mode="manual" class="composer-tab">Resposta Manual</button>
+          </div>
+
+          <form id="aiForm" class="composer-form visible">
+            <label for="aiPrompt">Pergunta ou contexto enviado pelo cliente</label>
+            <textarea id="aiPrompt" rows="3" placeholder="Descreva a pergunta do cliente..."></textarea>
+            <button type="submit" class="primary" disabled>Gerar e enviar com IA</button>
+          </form>
+
+          <form id="manualForm" class="composer-form">
+            <label for="manualMessage">Mensagem manual</label>
+            <textarea id="manualMessage" rows="3" placeholder="Digite a resposta que será enviada..."></textarea>
+            <button type="submit" class="primary" disabled>Enviar manualmente</button>
+          </form>
+        </div>
+      </section>
+    </main>
+
+    <template id="conversationItemTemplate">
+      <li class="conversation-item">
+        <div class="conversation-avatar">📱</div>
+        <div class="conversation-meta">
+          <strong class="conversation-title"></strong>
+          <span class="conversation-phone muted"></span>
+          <span class="conversation-last muted"></span>
+        </div>
+      </li>
+    </template>
+
+    <template id="messageTemplate">
+      <div class="message">
+        <div class="message-bubble">
+          <div class="message-body"></div>
+          <div class="message-meta"></div>
+        </div>
+      </div>
+    </template>
+
+    <div id="toast" class="toast" role="status" aria-live="polite"></div>
+
+    <script src="/app.js"></script>
+  </body>
+</html>

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,248 @@
+(() => {
+  const conversationList = document.querySelector('#conversationList');
+  const refreshConversationsButton = document.querySelector('#refreshConversations');
+  const refreshMessagesButton = document.querySelector('#refreshMessages');
+  const conversationTitle = document.querySelector('#conversationTitle');
+  const conversationSubtitle = document.querySelector('#conversationSubtitle');
+  const messageHistory = document.querySelector('#messageHistory');
+  const environmentLabel = document.querySelector('#environmentLabel');
+
+  const composerTabs = document.querySelectorAll('.composer-tab');
+  const aiForm = document.querySelector('#aiForm');
+  const manualForm = document.querySelector('#manualForm');
+  const aiPromptField = document.querySelector('#aiPrompt');
+  const manualMessageField = document.querySelector('#manualMessage');
+  const toast = document.querySelector('#toast');
+
+  let selectedConversation = null;
+  let conversations = [];
+  let environmentStatus = { hasOpenAI: false, hasWhatsApp: false };
+
+  function showToast(message, type = 'info') {
+    toast.textContent = message;
+    toast.dataset.type = type;
+    toast.classList.add('visible');
+    setTimeout(() => toast.classList.remove('visible'), 3200);
+  }
+
+  function setEnvironmentLabel() {
+    const parts = [];
+    parts.push(environmentStatus.hasOpenAI ? 'OpenAI ✅' : 'OpenAI ❌');
+    parts.push(environmentStatus.hasWhatsApp ? 'WhatsApp ✅' : 'WhatsApp ❌');
+    environmentLabel.textContent = parts.join(' · ');
+  }
+
+  function formatDate(iso) {
+    if (!iso) return '';
+    try {
+      return new Intl.DateTimeFormat('pt-BR', {
+        dateStyle: 'short',
+        timeStyle: 'short',
+      }).format(new Date(iso));
+    } catch (error) {
+      return iso;
+    }
+  }
+
+  function renderConversations(items) {
+    conversationList.innerHTML = '';
+    if (!items.length) {
+      const empty = document.createElement('li');
+      empty.className = 'muted';
+      empty.textContent = 'Nenhuma conversa registrada ainda.';
+      conversationList.appendChild(empty);
+      return;
+    }
+
+    const template = document.querySelector('#conversationItemTemplate');
+    items.forEach((conversation) => {
+      const node = template.content.firstElementChild.cloneNode(true);
+      node.querySelector('.conversation-title').textContent = conversation.title || 'Contato';
+      node.querySelector('.conversation-phone').textContent = conversation.phone;
+      node.querySelector('.conversation-last').textContent = conversation.lastMessage || 'Sem mensagens';
+      node.dataset.id = conversation.id;
+      if (selectedConversation?.id === conversation.id) {
+        node.classList.add('active');
+      }
+
+      node.addEventListener('click', () => {
+        selectedConversation = conversation;
+        renderConversations(conversations);
+        loadMessages();
+      });
+
+      conversationList.appendChild(node);
+    });
+  }
+
+  function renderMessages(messages) {
+    messageHistory.innerHTML = '';
+    if (!messages.length) {
+      const empty = document.createElement('div');
+      empty.className = 'empty-state';
+      empty.textContent = 'Ainda não há mensagens neste atendimento.';
+      messageHistory.appendChild(empty);
+      return;
+    }
+
+    const template = document.querySelector('#messageTemplate');
+    messages
+      .slice()
+      .reverse()
+      .forEach((message) => {
+        const node = template.content.firstElementChild.cloneNode(true);
+        node.classList.add(message.direction);
+        node.querySelector('.message-body').textContent = message.body;
+        node.querySelector('.message-meta').textContent = `${
+          message.direction === 'outbound' ? 'Enviado' : 'Recebido'
+        } • ${formatDate(message.createdAt)}${
+          message.metadata?.simulated ? ' • Simulação' : ''
+        }${message.status === 'error' ? ' • Erro' : ''}`;
+        messageHistory.appendChild(node);
+      });
+
+    messageHistory.scrollTop = messageHistory.scrollHeight;
+  }
+
+  async function fetchJSON(url, options) {
+    const response = await fetch(url, {
+      headers: { 'Content-Type': 'application/json' },
+      ...options,
+    });
+    if (!response.ok) {
+      const errorBody = await response.json().catch(() => ({}));
+      throw new Error(errorBody.error || 'Erro desconhecido');
+    }
+    return response.json();
+  }
+
+  async function loadStatus() {
+    try {
+      const status = await fetchJSON('/api/status');
+      environmentStatus = status;
+      setEnvironmentLabel();
+    } catch (error) {
+      showToast('Não foi possível verificar o status das integrações.', 'warning');
+    }
+  }
+
+  async function loadConversations() {
+    refreshConversationsButton.disabled = true;
+    try {
+      const data = await fetchJSON('/api/conversations');
+      conversations = data.conversations || [];
+      renderConversations(conversations);
+    } catch (error) {
+      showToast(error.message, 'error');
+    } finally {
+      refreshConversationsButton.disabled = false;
+    }
+  }
+
+  async function loadMessages() {
+    if (!selectedConversation) return;
+
+    refreshMessagesButton.disabled = true;
+    aiForm.querySelector('button').disabled = false;
+    manualForm.querySelector('button').disabled = false;
+    aiPromptField.disabled = false;
+    manualMessageField.disabled = false;
+
+    conversationTitle.textContent = selectedConversation.title || 'Contato';
+    conversationSubtitle.textContent = `Telefone: ${selectedConversation.phone}`;
+
+    try {
+      const data = await fetchJSON(`/api/messages?conversationId=${selectedConversation.id}`);
+      renderMessages(data.messages || []);
+    } catch (error) {
+      showToast(error.message, 'error');
+    } finally {
+      refreshMessagesButton.disabled = false;
+    }
+  }
+
+  async function submitAI(event) {
+    event.preventDefault();
+    if (!selectedConversation) return;
+    const prompt = aiPromptField.value.trim();
+    if (!prompt) {
+      showToast('Descreva a pergunta do cliente para gerar a resposta.', 'warning');
+      return;
+    }
+
+    aiForm.querySelector('button').disabled = true;
+    try {
+      const payload = {
+        phone: selectedConversation.phone,
+        prompt,
+      };
+      const data = await fetchJSON('/api/messages/send', {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      });
+      showToast('Resposta enviada com sucesso!');
+      aiPromptField.value = '';
+      await loadConversations();
+      await loadMessages();
+      console.log('AI Response', data);
+    } catch (error) {
+      showToast(error.message, 'error');
+    } finally {
+      aiForm.querySelector('button').disabled = false;
+    }
+  }
+
+  async function submitManual(event) {
+    event.preventDefault();
+    if (!selectedConversation) return;
+    const message = manualMessageField.value.trim();
+    if (!message) {
+      showToast('Digite uma mensagem para enviar.', 'warning');
+      return;
+    }
+
+    manualForm.querySelector('button').disabled = true;
+    try {
+      const payload = {
+        phone: selectedConversation.phone,
+        message,
+      };
+      await fetchJSON('/api/messages/manual', {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      });
+      showToast('Mensagem enviada com sucesso!');
+      manualMessageField.value = '';
+      await loadConversations();
+      await loadMessages();
+    } catch (error) {
+      showToast(error.message, 'error');
+    } finally {
+      manualForm.querySelector('button').disabled = false;
+    }
+  }
+
+  function switchTab(event) {
+    const { mode } = event.target.dataset;
+    if (!mode) return;
+
+    composerTabs.forEach((tab) => tab.classList.remove('active'));
+    event.target.classList.add('active');
+
+    aiForm.classList.toggle('visible', mode === 'ai');
+    manualForm.classList.toggle('visible', mode === 'manual');
+  }
+
+  async function bootstrap() {
+    await loadStatus();
+    await loadConversations();
+  }
+
+  refreshConversationsButton.addEventListener('click', loadConversations);
+  refreshMessagesButton.addEventListener('click', loadMessages);
+  aiForm.addEventListener('submit', submitAI);
+  manualForm.addEventListener('submit', submitManual);
+  composerTabs.forEach((tab) => tab.addEventListener('click', switchTab));
+
+  bootstrap();
+})();

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,307 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #f4f6fb;
+  color: #0f172a;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(180deg, #f8fbff 0%, #eef2ff 100%);
+}
+
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.25rem 2rem;
+  background: #0f172a;
+  color: #fff;
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.35);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.logo {
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.subtitle {
+  display: block;
+  font-size: 0.875rem;
+  opacity: 0.8;
+}
+
+.environment {
+  font-size: 0.875rem;
+}
+
+.app-layout {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 1.5rem;
+  padding: 1.5rem 2rem 2rem;
+  flex: 1;
+}
+
+section {
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 1rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.section-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.conversation-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  overflow-y: auto;
+  max-height: calc(100vh - 220px);
+}
+
+.conversation-item {
+  display: flex;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  border-radius: 0.85rem;
+  background: rgba(15, 23, 42, 0.04);
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.conversation-item:hover,
+.conversation-item.active {
+  background: linear-gradient(135deg, #3b82f6, #22d3ee);
+  color: #fff;
+  transform: translateY(-2px);
+}
+
+.conversation-item.active .muted,
+.conversation-item:hover .muted {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.conversation-avatar {
+  width: 44px;
+  height: 44px;
+  background: rgba(15, 23, 42, 0.09);
+  display: grid;
+  place-items: center;
+  border-radius: 12px;
+  font-size: 1.4rem;
+}
+
+.conversation-item.active .conversation-avatar,
+.conversation-item:hover .conversation-avatar {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.conversation-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.conversation-title {
+  font-size: 1rem;
+}
+
+.muted {
+  color: #64748b;
+  font-size: 0.85rem;
+}
+
+.message-history {
+  flex: 1;
+  overflow-y: auto;
+  background: rgba(15, 23, 42, 0.03);
+  border-radius: 1rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.message {
+  display: flex;
+}
+
+.message-bubble {
+  max-width: 75%;
+  padding: 0.85rem 1rem;
+  border-radius: 1rem;
+  background: #e2e8f0;
+  color: #0f172a;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.12);
+}
+
+.message.outbound {
+  justify-content: flex-end;
+}
+
+.message.outbound .message-bubble {
+  background: linear-gradient(135deg, #3b82f6, #22d3ee);
+  color: #fff;
+}
+
+.message.inbound .message-bubble {
+  background: #fff;
+}
+
+.message-meta {
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
+  opacity: 0.8;
+}
+
+.empty-state {
+  margin: auto;
+  text-align: center;
+  color: #94a3b8;
+}
+
+.composer {
+  margin-top: 1rem;
+  background: rgba(15, 23, 42, 0.04);
+  border-radius: 1rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.composer-tabs {
+  display: inline-flex;
+  background: rgba(15, 23, 42, 0.07);
+  border-radius: 999px;
+  padding: 0.25rem;
+  gap: 0.35rem;
+}
+
+.composer-tab {
+  border: none;
+  background: transparent;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  cursor: pointer;
+  font-weight: 600;
+  color: #475569;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.composer-tab.active {
+  background: #fff;
+  color: #2563eb;
+  box-shadow: 0 8px 20px rgba(37, 99, 235, 0.25);
+}
+
+.composer-form {
+  display: none;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.composer-form.visible {
+  display: flex;
+}
+
+label {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+textarea {
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  padding: 0.75rem;
+  font: inherit;
+  resize: vertical;
+  min-height: 100px;
+}
+
+textarea:focus {
+  outline: 2px solid rgba(37, 99, 235, 0.4);
+}
+
+button {
+  border-radius: 0.75rem;
+  border: none;
+  padding: 0.65rem 1.1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+button.primary {
+  background: linear-gradient(135deg, #3b82f6, #22d3ee);
+  color: #fff;
+  box-shadow: 0 15px 30px rgba(37, 99, 235, 0.3);
+}
+
+button.primary:not(:disabled):hover {
+  transform: translateY(-1px);
+}
+
+button.secondary {
+  background: rgba(148, 163, 184, 0.2);
+  color: #334155;
+}
+
+.toast {
+  position: fixed;
+  right: 2rem;
+  bottom: 2rem;
+  background: #0f172a;
+  color: #fff;
+  padding: 0.85rem 1.2rem;
+  border-radius: 0.75rem;
+  box-shadow: 0 20px 30px rgba(15, 23, 42, 0.25);
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  pointer-events: none;
+}
+
+.toast.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (max-width: 1024px) {
+  .app-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .conversations {
+    max-height: 320px;
+  }
+}

--- a/src/controllers/api.js
+++ b/src/controllers/api.js
@@ -1,0 +1,229 @@
+const db = require('../database');
+const { parseRequestBody, sendJson } = require('../utils/http');
+const { generateResponse } = require('../services/openai');
+const { sendTextMessage } = require('../services/whatsapp');
+const { log } = require('../utils/logger');
+
+async function handleApiRequest(req, res, parsedUrl) {
+  const { pathname, query } = parsedUrl;
+
+  if (req.method === 'OPTIONS') {
+    sendJson(res, 200, { ok: true });
+    return;
+  }
+
+  if (pathname === '/api/messages' && req.method === 'GET') {
+    const { conversationId, limit } = query;
+    const limitNumber = Number(limit) || 50;
+    const messages = conversationId
+      ? db.listMessagesByConversation(conversationId)
+      : db.listMessages(limitNumber);
+
+    sendJson(res, 200, { messages });
+    return;
+  }
+
+  if (pathname === '/api/conversations' && req.method === 'GET') {
+    const conversations = db.listConversations();
+    sendJson(res, 200, { conversations });
+    return;
+  }
+
+  if (pathname === '/api/status' && req.method === 'GET') {
+    const status = {
+      hasOpenAI: Boolean(process.env.OPENAI_API_KEY),
+      hasWhatsApp: Boolean(process.env.WHATSAPP_ACCESS_TOKEN && process.env.WHATSAPP_PHONE_NUMBER_ID),
+    };
+    sendJson(res, 200, status);
+    return;
+  }
+
+  if (pathname === '/api/messages/send' && req.method === 'POST') {
+    try {
+      const body = (await parseRequestBody(req)) || {};
+      const { phone, prompt } = body;
+
+      if (!phone || !prompt) {
+        sendJson(res, 400, { error: 'Os campos phone e prompt são obrigatórios.' });
+        return;
+      }
+
+      const conversation =
+        db.findConversationByPhone(phone) ||
+        db.upsertConversation({ id: undefined, phone, title: `Contato ${phone}` });
+
+      const aiResponse = await generateResponse({
+        prompt,
+        context: db.listMessagesByConversation(conversation.id)
+          .slice(0, 10)
+          .reverse()
+          .map((message) => ({
+            role: message.direction === 'inbound' ? 'user' : 'assistant',
+            content: message.body,
+          })),
+      });
+
+      const inboundRecord = db.createMessage({
+        conversationId: conversation.id,
+        phone,
+        direction: 'inbound',
+        body: prompt,
+        status: 'received',
+        metadata: {},
+      });
+
+      const outboundMessage = aiResponse.content;
+      const whatsappResult = await sendTextMessage({ to: phone, body: outboundMessage });
+
+      db.createMessage({
+        conversationId: conversation.id,
+        phone,
+        direction: 'outbound',
+        body: outboundMessage,
+        status: whatsappResult.success ? 'sent' : 'error',
+        metadata: {
+          simulated: whatsappResult.simulated || false,
+          error: whatsappResult.error,
+          aiMock: aiResponse.isMock,
+        },
+        replyTo: inboundRecord.id,
+      });
+
+      db.upsertConversation({
+        id: conversation.id,
+        phone,
+        title: conversation.title,
+        lastMessage: outboundMessage,
+      });
+
+      sendJson(res, 200, {
+        success: true,
+        aiResponse: outboundMessage,
+        whatsappResult,
+      });
+    } catch (error) {
+      sendJson(res, 500, { error: error.message });
+    }
+    return;
+  }
+
+  if (pathname === '/api/messages/manual' && req.method === 'POST') {
+    try {
+      const body = (await parseRequestBody(req)) || {};
+      const { phone, message } = body;
+      if (!phone || !message) {
+        sendJson(res, 400, { error: 'Os campos phone e message são obrigatórios.' });
+        return;
+      }
+
+      const conversation =
+        db.findConversationByPhone(phone) ||
+        db.upsertConversation({ id: undefined, phone, title: `Contato ${phone}` });
+
+      const whatsappResult = await sendTextMessage({ to: phone, body: message });
+
+      db.createMessage({
+        conversationId: conversation.id,
+        phone,
+        direction: 'outbound',
+        body: message,
+        status: whatsappResult.success ? 'sent' : 'error',
+        metadata: {
+          simulated: whatsappResult.simulated || false,
+          error: whatsappResult.error,
+        },
+      });
+
+      db.upsertConversation({
+        id: conversation.id,
+        phone,
+        title: conversation.title,
+        lastMessage: message,
+      });
+
+      sendJson(res, 200, {
+        success: whatsappResult.success,
+        whatsappResult,
+      });
+    } catch (error) {
+      sendJson(res, 500, { error: error.message });
+    }
+    return;
+  }
+
+  sendJson(res, 404, { error: 'Rota não encontrada.' });
+}
+
+async function handleWhatsappWebhook(req, res, parsedUrl) {
+  const { pathname, query } = parsedUrl;
+
+  if (pathname !== '/webhooks/whatsapp') {
+    return false;
+  }
+
+  if (req.method === 'GET') {
+    const { 'hub.mode': mode, 'hub.verify_token': verifyToken, 'hub.challenge': challenge } = query;
+    if (mode === 'subscribe' && verifyToken === process.env.WHATSAPP_VERIFY_TOKEN) {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end(challenge);
+    } else {
+      res.writeHead(403, { 'Content-Type': 'text/plain' });
+      res.end('Verificação não autorizada.');
+    }
+    return true;
+  }
+
+  if (req.method === 'POST') {
+    try {
+      const body = (await parseRequestBody(req)) || {};
+      const entries = body.entry || [];
+      entries.forEach((entry) => {
+        const changes = entry.changes || [];
+        changes.forEach((change) => {
+          const messages = change.value?.messages || [];
+          messages.forEach((message) => {
+            const phone = message.from;
+            const text = message.text?.body;
+            if (!phone || !text) {
+              return;
+            }
+
+            const conversation =
+              db.findConversationByPhone(phone) ||
+              db.upsertConversation({ id: undefined, phone, title: `Contato ${phone}` });
+
+            db.createMessage({
+              conversationId: conversation.id,
+              phone,
+              direction: 'inbound',
+              body: text,
+              status: 'received',
+              metadata: { messageId: message.id },
+            });
+
+            db.upsertConversation({
+              id: conversation.id,
+              phone,
+              title: conversation.title,
+              lastMessage: text,
+            });
+          });
+        });
+      });
+
+      log('Webhook do WhatsApp processado com sucesso.');
+      sendJson(res, 200, { success: true });
+    } catch (error) {
+      sendJson(res, 500, { error: error.message });
+    }
+    return true;
+  }
+
+  sendJson(res, 404, { error: 'Não suportado.' });
+  return true;
+}
+
+module.exports = {
+  handleApiRequest,
+  handleWhatsappWebhook,
+};

--- a/src/database.js
+++ b/src/database.js
@@ -1,0 +1,106 @@
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_DATA = {
+  messages: [],
+  conversations: [],
+};
+
+class Database {
+  constructor(filePath) {
+    this.filePath = filePath;
+    this.data = DEFAULT_DATA;
+    this._load();
+  }
+
+  _load() {
+    try {
+      if (!fs.existsSync(this.filePath)) {
+        this._persist(DEFAULT_DATA);
+        this.data = JSON.parse(JSON.stringify(DEFAULT_DATA));
+        return;
+      }
+
+      const raw = fs.readFileSync(this.filePath, 'utf-8');
+      this.data = JSON.parse(raw);
+    } catch (error) {
+      console.error('Failed to load database file. Falling back to empty store.', error);
+      this.data = JSON.parse(JSON.stringify(DEFAULT_DATA));
+    }
+  }
+
+  _persist(data) {
+    const dir = path.dirname(this.filePath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+
+    fs.writeFileSync(this.filePath, JSON.stringify(data, null, 2));
+  }
+
+  _save() {
+    this._persist(this.data);
+  }
+
+  _generateId(prefix) {
+    return `${prefix}_${Math.random().toString(36).slice(2, 10)}`;
+  }
+
+  createMessage(message) {
+    const record = {
+      id: this._generateId('msg'),
+      createdAt: new Date().toISOString(),
+      ...message,
+    };
+
+    this.data.messages.unshift(record);
+    this._save();
+    return record;
+  }
+
+  listMessages(limit = 50) {
+    return this.data.messages.slice(0, limit);
+  }
+
+  listMessagesByConversation(conversationId) {
+    return this.data.messages.filter((message) => message.conversationId === conversationId);
+  }
+
+  upsertConversation(conversation) {
+    const existingIndex = this.data.conversations.findIndex((item) => item.id === conversation.id);
+    const record = {
+      updatedAt: new Date().toISOString(),
+      ...conversation,
+    };
+
+    if (existingIndex >= 0) {
+      this.data.conversations[existingIndex] = {
+        ...this.data.conversations[existingIndex],
+        ...record,
+      };
+    } else {
+      if (!record.id) {
+        record.id = this._generateId('conv');
+      }
+      record.createdAt = new Date().toISOString();
+      this.data.conversations.unshift(record);
+    }
+
+    this._save();
+    return record;
+  }
+
+  findConversationByPhone(phone) {
+    return this.data.conversations.find((item) => item.phone === phone);
+  }
+
+  listConversations() {
+    return this.data.conversations.slice();
+  }
+}
+
+const databaseFile = path.join(__dirname, '..', 'data', 'database.json');
+
+const db = new Database(databaseFile);
+
+module.exports = db;

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,45 @@
+const http = require('http');
+const url = require('url');
+const path = require('path');
+const { handleApiRequest, handleWhatsappWebhook } = require('./controllers/api');
+const { serveStaticFile } = require('./utils/static');
+const { log } = require('./utils/logger');
+const { loadEnv } = require('./utils/env');
+
+loadEnv();
+
+const PORT = process.env.PORT ? Number(process.env.PORT) : 3000;
+
+const server = http.createServer(async (req, res) => {
+  const parsedUrl = url.parse(req.url, true);
+  const { pathname } = parsedUrl;
+
+  log(`Requisição recebida: ${req.method} ${pathname}`);
+
+  if (await handleWhatsappWebhook(req, res, parsedUrl)) {
+    return;
+  }
+
+  if (pathname.startsWith('/api/')) {
+    await handleApiRequest(req, res, parsedUrl);
+    return;
+  }
+
+  if (req.method === 'GET' && (pathname === '/' || pathname === '/admin')) {
+    serveStaticFile(res, path.join(__dirname, '..', 'public', 'admin.html'));
+    return;
+  }
+
+  if (req.method === 'GET') {
+    const filePath = path.join(__dirname, '..', 'public', pathname);
+    serveStaticFile(res, filePath);
+    return;
+  }
+
+  res.writeHead(404, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ error: 'Rota não encontrada.' }));
+});
+
+server.listen(PORT, () => {
+  log(`Servidor iniciado na porta ${PORT}`);
+});

--- a/src/services/openai.js
+++ b/src/services/openai.js
@@ -1,0 +1,65 @@
+const { log, logError } = require('../utils/logger');
+
+const OPENAI_BASE_URL = process.env.OPENAI_BASE_URL || 'https://api.openai.com/v1';
+const OPENAI_MODEL = process.env.OPENAI_MODEL || 'gpt-4o-mini';
+
+async function generateResponse({ prompt, context = [] }) {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    log('OPENAI_API_KEY não configurada. Retornando resposta simulada.');
+    return {
+      content: 'Configurar a variável de ambiente OPENAI_API_KEY para receber respostas reais da IA.',
+      isMock: true,
+    };
+  }
+
+  const messages = [
+    {
+      role: 'system',
+      content: 'Você é um assistente especializado em atendimento ao cliente para a plataforma ContrataMais. Responda sempre em português e mantenha um tom profissional.',
+    },
+    ...context,
+    {
+      role: 'user',
+      content: prompt,
+    },
+  ];
+
+  try {
+    const response = await fetch(`${OPENAI_BASE_URL}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: OPENAI_MODEL,
+        messages,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new Error(`Erro na chamada da OpenAI: ${response.status} ${errorBody}`);
+    }
+
+    const data = await response.json();
+    const message = data.choices?.[0]?.message?.content?.trim() || '';
+    log('Resposta recebida da OpenAI');
+    return {
+      content: message,
+      isMock: false,
+      raw: data,
+    };
+  } catch (error) {
+    logError('Falha ao gerar resposta na OpenAI', error);
+    return {
+      content: 'Não foi possível gerar uma resposta inteligente neste momento. Tente novamente mais tarde.',
+      isMock: true,
+    };
+  }
+}
+
+module.exports = {
+  generateResponse,
+};

--- a/src/services/whatsapp.js
+++ b/src/services/whatsapp.js
@@ -1,0 +1,65 @@
+const { log, logError } = require('../utils/logger');
+
+const GRAPH_BASE_URL = 'https://graph.facebook.com/v20.0';
+
+function getCredentials() {
+  const phoneId = process.env.WHATSAPP_PHONE_NUMBER_ID;
+  const token = process.env.WHATSAPP_ACCESS_TOKEN;
+
+  if (!phoneId || !token) {
+    log('Credenciais do WhatsApp Cloud API não configuradas. Ativando modo simulado.');
+  }
+
+  return { phoneId, token };
+}
+
+async function sendTextMessage({ to, body }) {
+  const { phoneId, token } = getCredentials();
+
+  if (!phoneId || !token) {
+    log('Mensagem enviada em modo simulado para o WhatsApp.', { to, body });
+    return {
+      success: true,
+      simulated: true,
+    };
+  }
+
+  try {
+    const response = await fetch(`${GRAPH_BASE_URL}/${phoneId}/messages`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        messaging_product: 'whatsapp',
+        to,
+        type: 'text',
+        text: { body },
+      }),
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new Error(`Erro na API do WhatsApp: ${response.status} ${errorBody}`);
+    }
+
+    const data = await response.json();
+    log('Mensagem enviada para o WhatsApp com sucesso.', { to });
+    return {
+      success: true,
+      simulated: false,
+      data,
+    };
+  } catch (error) {
+    logError('Falha ao enviar mensagem pelo WhatsApp', error, { to });
+    return {
+      success: false,
+      error: error.message,
+    };
+  }
+}
+
+module.exports = {
+  sendTextMessage,
+};

--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const path = require('path');
+
+function loadEnv() {
+  const envPath = path.join(process.cwd(), '.env');
+  if (!fs.existsSync(envPath)) {
+    return;
+  }
+
+  const content = fs.readFileSync(envPath, 'utf-8');
+  content
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'))
+    .forEach((line) => {
+      const [key, ...rest] = line.split('=');
+      const value = rest.join('=');
+      if (key && !(key in process.env)) {
+        process.env[key] = value;
+      }
+    });
+}
+
+module.exports = {
+  loadEnv,
+};

--- a/src/utils/http.js
+++ b/src/utils/http.js
@@ -1,0 +1,56 @@
+const { StringDecoder } = require('string_decoder');
+
+async function parseRequestBody(req) {
+  return new Promise((resolve, reject) => {
+    const decoder = new StringDecoder('utf-8');
+    let buffer = '';
+
+    req.on('data', (data) => {
+      buffer += decoder.write(data);
+    });
+
+    req.on('end', () => {
+      buffer += decoder.end();
+      if (!buffer) {
+        resolve(null);
+        return;
+      }
+
+      const contentType = req.headers['content-type'] || '';
+
+      try {
+        if (contentType.includes('application/json')) {
+          resolve(JSON.parse(buffer));
+        } else if (contentType.includes('application/x-www-form-urlencoded')) {
+          const params = new URLSearchParams(buffer);
+          const result = {};
+          params.forEach((value, key) => {
+            result[key] = value;
+          });
+          resolve(result);
+        } else {
+          resolve(buffer);
+        }
+      } catch (error) {
+        reject(error);
+      }
+    });
+
+    req.on('error', reject);
+  });
+}
+
+function sendJson(res, statusCode, payload) {
+  res.writeHead(statusCode, {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type,X-Requested-With',
+  });
+  res.end(JSON.stringify(payload));
+}
+
+module.exports = {
+  parseRequestBody,
+  sendJson,
+};

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,0 +1,19 @@
+function log(message, context = {}) {
+  const timestamp = new Date().toISOString();
+  const payload = Object.keys(context).length ? ` ${JSON.stringify(context)}` : '';
+  console.log(`[${timestamp}] ${message}${payload}`);
+}
+
+function logError(message, error, context = {}) {
+  const timestamp = new Date().toISOString();
+  const payload = {
+    ...context,
+    error: error instanceof Error ? error.message : error,
+  };
+  console.error(`[${timestamp}] ERROR ${message} ${JSON.stringify(payload)}`);
+}
+
+module.exports = {
+  log,
+  logError,
+};

--- a/src/utils/static.js
+++ b/src/utils/static.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+
+const MIME_TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+};
+
+function serveStaticFile(res, filePath) {
+  if (!fs.existsSync(filePath)) {
+    res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end('Arquivo não encontrado');
+    return;
+  }
+
+  const ext = path.extname(filePath);
+  const mimeType = MIME_TYPES[ext] || 'text/plain; charset=utf-8';
+
+  res.writeHead(200, { 'Content-Type': mimeType });
+  const stream = fs.createReadStream(filePath);
+  stream.pipe(res);
+}
+
+module.exports = {
+  serveStaticFile,
+};


### PR DESCRIPTION
## Summary
- implement Node.js HTTP server that serves a WhatsApp webhook, REST API, and admin dashboard powered by OpenAI replies
- add file-based database, OpenAI and WhatsApp service layers, and utility helpers for env loading, logging, and static assets
- provide responsive administrative UI for managing conversations and sending AI-assisted or manual replies

## Testing
- node -e "require('./src/server'); setTimeout(() => process.exit(0), 500);"

------
https://chatgpt.com/codex/tasks/task_e_68f542e43ca4832687f818fde5b061e5